### PR TITLE
Resource URL should be updated even if the target minified file exists

### DIFF
--- a/src/groovy/com/blockconsult/yuiminifyresources/Util.groovy
+++ b/src/groovy/com/blockconsult/yuiminifyresources/Util.groovy
@@ -62,6 +62,8 @@ class Util {
     File targetFile = new File(inputFile.parentFile, targetFileName)
     if (targetFile.exists()) {
       if (log.debugEnabled) log.debug "Skip minifying [$inputFile] as minified version exists. Using that version instead."
+      resource.processedFile = targetFile
+      resource.updateActualUrlFromProcessedFile()
       return null
     }
 


### PR DESCRIPTION
Looks like the minified resources don't get used if they already exist. Added a quick fix to Util.groovy.
