### PR TITLE
Deprecate 'noMunge' in favor of 'munge'

### DIFF
--- a/YuiMinifyResourcesGrailsPlugin.groovy
+++ b/YuiMinifyResourcesGrailsPlugin.groovy
@@ -1,6 +1,6 @@
 class YuiMinifyResourcesGrailsPlugin {
   // the plugin version
-  def version = "0.1.5"
+  def version = "0.1.6"
   // the version or versions of Grails the plugin is designed for
   def grailsVersion = "1.2 > *"
   // the other plugins this plugin depends on

--- a/grails-app/resourceMappers/com/blockconsult/yuiminifyresources/YuiJsMinifyResourceMapper.groovy
+++ b/grails-app/resourceMappers/com/blockconsult/yuiminifyresources/YuiJsMinifyResourceMapper.groovy
@@ -28,11 +28,22 @@ class YuiJsMinifyResourceMapper {
       inputFile.withReader(encoding) {
         compressor = new JavaScriptCompressor(it, new YuiCompressorErrorReporter())
       }
+      /* Henceforth, "munge" should be used instead of "noMunge", but "noMunge" is kept for backwards compatibility.
+       * Also, "noMunge" has its boolean logic backwards, in order to support developers who were relying
+       * on the buggy behavior. Therefore their code won't suddenly start un-munging when they upgrade this plugin.
+       * @see https://github.com/cblock/yui-minify-resources/issues/4
+       */
+      boolean munge = config?.munge ?: (config?.noMunge?.equals(Boolean.TRUE) ?: false);
+      if (config.noMunge != null) { // user defined 'noMunge'
+          log.warn("[DEPRECATED] The config param 'noMunge' has been deprecated " + 
+              "and is highly unrecommended! Please use grails.resources.mappers.yuijsminify.munge " + 
+              "in your Config.groovy instead.")
+      }
       if (compressor) {
         targetFile.withWriter(encoding) {
           compressor.compress(it,
               (config?.lineBreak ?: -1),
-              (config?.noMunge ?: false),
+              munge,
               false, //non-verbose
               (config?.preserveAllSemicolons ?: false),
               (config?.disableOptimizations ?: false)

--- a/src/groovy/com/blockconsult/yuiminifyresources/YuiCompressorConfig.groovy
+++ b/src/groovy/com/blockconsult/yuiminifyresources/YuiCompressorConfig.groovy
@@ -9,11 +9,17 @@ package com.blockconsult.yuiminifyresources
 class YuiCompressorConfig {
   int lineBreak = -1
   String charset = 'UTF-8'
-  boolean noMunge = false
+  
+  /*
+   * Henceforth, "munge" should be used instead of "noMunge", but "noMunge" is kept for backwards compatibility. 
+   * @deprecated
+   */
+  Boolean noMunge = null; // use Boolean in order to do a null test
+  boolean munge = false
   boolean preserveAllSemicolons = false
   boolean disableOptimizations = false
 
   public String toString() {
-    "[lineBreak: $lineBreak, charset: $charset, noMunge: $noMunge, preserveAllSemicolons: $preserveAllSemicolons, disableOptimizations: $disableOptimizations]"
+    "[lineBreak: $lineBreak, charset: $charset, munge: $munge, noMunge: $noMunge, preserveAllSemicolons: $preserveAllSemicolons, disableOptimizations: $disableOptimizations]"
   }
 }


### PR DESCRIPTION
This shows what I had in mind for migrating from `noMunge` to `munge` (as discussed in [Issue #4](https://github.com/cblock/yui-minify-resources/issues/4)).

Unfortunately I _have not been able to test this_ because Grails seems to be finicky with installing plugins manually.  How did you ever get it to work?  My method is to run `grails package-plugin` on the plugin folder, then move the zip file over to another project's `lib/` folder, but every time I do so, it picks up an older version of the plugin I installed.  Even deleting the `~/.grails` directory, running `uninstall-plugin`, and upgrading the plugin version doesn't seem to work.  I'm seriously considering just testing this on another machine, because I don't know where Grails is getting the old zip file from.

In any case, the only part I'm unsure about is the warning message, which I would like to log only if the user specifies `noMunge` (either false or true, doesn't matter) so that I can warn them to use `munge` instead.  Other than that, this should be a super-simple code change.
